### PR TITLE
No more fractional zoom

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -768,6 +768,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // import.meta.env.PROD flag to detect production mode.
     validateStyle: import.meta.env.PROD ? false : true,
     center: [5.12, 52.37], // Netherlands center in WGS84
+    cancelPendingTileRequestsWhileZooming: false,
     zoom: 8,
     maxZoom: 17,
     minZoom: 7,
@@ -811,6 +812,8 @@ document.addEventListener('DOMContentLoaded', function () {
   requestAnimationFrame(() => {
     map.resize();
   });
+
+  map.scrollZoom.setWheelZoomRate(1);
 
   // Load initial data for visible layers
   map.on('load', async () => {

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -688,8 +688,8 @@ document.addEventListener('DOMContentLoaded', function () {
             'https://kaartserver.incidentcentrale.nl/{z}/{x}/{y}.png',
         ],
         tileSize: 256,
-        minZoom: 7,
-        maxZoom: 17,
+        minzoom: 7,
+        maxzoom: 17,
         bounds: [2.81, 50.29, 8.43, 53.75],
       },
     };


### PR DESCRIPTION
We're no longer using fractional zoom levels. We're only using the discrete zoom levels available on the tile server. Furthermore, we're no longer requesting tiles beyond the bounds and minimum zoom level and maximum zoom level, preventing the application to request tiles from the tile server that are not available. Fetching the available tiles are not being queued behind pointless requests for tiles that are not available.